### PR TITLE
Remove broken contact info

### DIFF
--- a/index.md
+++ b/index.md
@@ -41,10 +41,6 @@ other improvements have been made to Strata Source, including:
 - Sentry crash report integration
 - And much much more!
 
-If your team has signed an NDA with Valve and would like to join Strata, please
-reach out to us at team@chaosinitiative.com or on our public
-[Discord server](https://discord.gg/AhkqPBb)
-
 ## Projects Using Strata
 
 Right now, the following games are using Strata:


### PR DESCRIPTION
These links are broken, and we no longer advertise some of this info.