### PR TITLE
[Strata Source Index Page] Portal 2 is older than CSGO.

### DIFF
--- a/pages/shared/index.md
+++ b/pages/shared/index.md
@@ -12,7 +12,7 @@ more information.
 ## Features
 
 Strata Source started development in the June of 2020 as a fork of CSGO's engine branch
-with Portal 2 features backported. Since its inception, many features, fixes and
+with Portal 2 features ported over. Since its inception, many features, fixes and
 other improvements have been made to Strata Source, including:
 
 - Native DirectX 11 renderer


### PR DESCRIPTION
original sentence that was modified read: 
> Strata Source started development in the June of 2020 as a fork of CSGO’s engine branch *with Portal 2 features backported*.

Backporting is when you take features from a newer version of software and port them to an older version of the software.

The implication that was made here was that Portal 2 is newer than CSGO, which is *very incorrect* given CSGO released *after* Portal 2, and has it's engine branch branching off of Portal 2's.

As such the correct phrasing would be to say that the features were ported over, not backported.