### PR TITLE
Merge in the old GitHub wiki pages and basic documentation for vtex and vtex2

### DIFF
--- a/pages/p2ce/meta.json
+++ b/pages/p2ce/meta.json
@@ -8,11 +8,12 @@
         {
             "label": "Reference",
             "id": "reference",
-            "home": "reference",
+            "home": "general",
             "topics": [
                 {
-                    "id": "reference",
-                    "name": "Reference"
+					"path": "reference",
+                    "id": "general",
+                    "name": "General"
                 },
 				{
                     "path": "reference/util",

--- a/pages/p2ce/meta.json
+++ b/pages/p2ce/meta.json
@@ -13,6 +13,11 @@
                 {
                     "id": "reference",
                     "name": "Reference"
+                },
+				{
+                    "path": "reference/util",
+                    "id": "util",
+                    "name": "Utils"
                 }
             ]
         },

--- a/pages/shared/meta.json
+++ b/pages/shared/meta.json
@@ -12,6 +12,11 @@
                 {
                     "id": "reference",
                     "name": "Reference"
+                },
+				{
+                    "path": "reference/util",
+                    "id": "util",
+                    "name": "Utils"
                 }
             ]
         },

--- a/pages/shared/meta.json
+++ b/pages/shared/meta.json
@@ -7,11 +7,12 @@
         {
             "label": "Reference",
             "id": "reference",
-            "home": "reference",
+            "home": "general",
             "topics": [
                 {
-                    "id": "reference",
-                    "name": "Reference"
+					"path": "reference",
+                    "id": "general",
+                    "name": "General"
                 },
 				{
                     "path": "reference/util",

--- a/pages/shared/reference/util/dmxconvert.md
+++ b/pages/shared/reference/util/dmxconvert.md
@@ -1,0 +1,65 @@
+---
+title: dmxconvert
+---
+
+# dmxconvert
+
+dmxconvert is a command line utility that converts between different datamodel types and encodings. It is available for Windows and Linux.
+
+## Help Text
+
+```
+Usage: dmxconvert -i <in file> [-ie <in encoding hint>] [-o <out file>] [-oe <out encoding>] [-of <out format>]
+     -i, --input               - Input file name
+     -o, --output              - Output filename
+     -ie, --input-encoding     - Input encoding hint
+     -of, --output-format      - Output format
+     -oe, --output-encoding    - Output encoding
+If no output file is specified, dmx to dmx conversion will overwrite the input
+Supported DMX file encodings:
+   keyvalues
+   keyvalues2
+   keyvalues2_flat
+   binary
+   actbusy
+   commentary
+   vmt
+   vmf
+   mks
+   tex_source1
+Supported DMX file formats:
+   dmx
+   movieobjects
+   sfm
+   sfm_settings
+   sfm_session
+   sfm_trackgroup
+   pcf
+   gui
+   schema
+   preset
+   facial_animation
+   model
+   ved
+   mks
+   mp_preprocess
+   mp_root
+   mp_model
+   mp_anim
+   mp_physics
+   mp_hitbox
+   mp_materialgroup
+   mp_keyvalues
+   mp_eyes
+   mp_bonemask
+   tex
+   world
+   worldnode
+```
+
+## Usage Examples
+
+Example 1: Converting a DMX encoded file to keyvalues2.
+```
+./bin/linux64/dmxconvert -i medic_lod_03_high.dmx -o medic_lod_03_high.kv2 -oe keyvalues2
+```

--- a/pages/shared/reference/util/index.md
+++ b/pages/shared/reference/util/index.md
@@ -1,0 +1,7 @@
+---
+title: Overview
+---
+
+# Command Line Utilities
+
+Documentation pertaining to CLI tools.

--- a/pages/shared/reference/util/kv3t.md
+++ b/pages/shared/reference/util/kv3t.md
@@ -1,0 +1,63 @@
+---
+title: kv3t
+---
+
+# kv3t
+
+kv3t is a command line utility that converts KeyValues3 files to and from any format or encoding. The utility can also convert KeyValues1 files into KeyValues3. It is available for Windows and Linux.
+
+Supported formats:
+* `generic`
+
+Supported encodings:
+* `text`
+* `binary`
+* `binary_bc` (block-compressed binary)
+
+Supported input files:
+* Any KV3 file
+* text KeyValues1
+
+## Help Text
+
+```
+------------------------------------------------------------------
+KV3T - A tool for dealing with KeyValues3 files
+KeyValues3 - Copyright (c) Valve Corporation, All rights reserved.
+Tool developed by the Strata Source Team
+------------------------------------------------------------------
+SYNOPSIS
+kv3t <input> [options] [-o output]
+
+DESCRIPTION
+        Read and convert KeyValues3 ("KV3") files from and to any format. If no output is specified, print to stdout as text.
+        KV3 input formats and encoding will be automatically detected.
+
+COMMAND-LINE OPTIONS
+        -inh | --input-no-header
+                Specify that your input file doesn't have a header. Interpret as 'generic' and 'text', which is not guaranteed to work.
+        -ikv1 | --input-is-kv1
+                Specify that the input file is in the original KeyValues format ("KV1") and try to convert it.
+                Doesn't support advanced conversion rules for now.
+        -ikv1es | --input-kv1-escape-sequences
+                Enable escape sequence support for KV1 input files.
+        --kv1-multiroot
+                Enable support for multiple root keys. Needed for sound scripts, VMF, etc.
+        -of <FORMAT> | --output-format <FORMAT>
+                Request a special KV3 output format. Only 'generic' (default) is supported for now.
+        -oe <ENCODING> | --output-encoding <ENCODING>
+                Request a special KV3 output encoding when writing to a file. Supports 'text' for plain text (default),
+                'binary' for simple binary encoding and 'binary_bc' for block-compressed binary encoding
+```
+
+## Usage Examples
+
+Example 1: Convert binary KeyValues3 to text
+```
+kv3t myfile.kv3 -oe text myfile_text.kv3
+```
+
+Example 2: Convert text KeyValues3 to binary compressed
+```
+kv3t myfile_text.kv3 -oe binary_bc myfile.kv3
+```

--- a/pages/shared/reference/util/studiomdl.md
+++ b/pages/shared/reference/util/studiomdl.md
@@ -1,0 +1,198 @@
+---
+title: studiomdl
+---
+
+# studiomdl
+
+studiomdl is the MDL compiler shipped with all branches of Source. In Strata, mdlcompile's functionality was merged into studiomdl. It is available for Windows and Linux.
+
+The following input model formats are supported:
+* SMD
+* DMX
+* FBX
+* OBJ
+
+## Help Text
+
+```
+Usage: studiomdl.exe [options] <file.qc>
+
+Options:
+  [-a <normal_blend_angle>]
+  [-checklengths]
+  [-d] - dump glview files
+  [-definebones]
+  [-f] - flip all triangles
+  [-fullcollide] - don't truncate really big collisionmodels
+  [-game <gamedir>]
+  [-h] - dump hboxes
+  [-i] - ignore warnings
+  [-minlod <lod>] - truncate to highest detail <lod>
+  [-n] - tag bad normals
+  [-perf] report perf info upon compiling model
+  [-printbones]
+  [-printgraph]
+  [-quiet] - operate silently
+  [-r] - tag reversed
+  [-t <texture>]
+  [-fastbuild] - write a single vertex windings file
+  [-nowarnings] - disable warnings
+  [-dumpmaterials] - dump out material names
+  [-mdlreport] model.mdl - report perf info
+  [-mdlreportspreadsheet] - report perf info as a comma-delimited spreadsheet
+  [-striplods] - use only lod0
+  [-overridedefinebones] - equivalent to specifying $unlockdefinebones in qc file
+  [-stripmodel] - process binary model files and strip extra lod data
+  [-stripvhv] - strip hardware verts to match the stripped model
+  [-vsi] - generate stripping information .vsi file - can be used on .mdl files too
+  [-allowdebug]
+  [-overridedefinebones]
+  [-verbose]
+  [-makefile]
+  [-verify]
+  [-fastbuild]
+  [-maxwarnings]
+  [-preview]
+  [-dumpmaterials]
+  [-basedir]
+  [-tempcontent]
+  [-outdir <dir>] - directory to place the resultant model into. ie, /some/path will create the model /some/path/mymdl.mdl
+```
+
+# List of StudioMDL commands (.qc scripts)
+
+| Command | Parameters | Description |
+|---|---|---|
+| `$cd` | `string directory` | Directory to change to |
+| `$modelname` | `string modelName` | Set the name of the model, relative to the `models/` directory, including the `.mdl` extension |
+| `$internalname` | `string internalName` | Set the internal name of the model. This will be used as the name of the `.ani` file |
+| `$cdmaterials` | `string materialsPath` | Set the materials path |
+| `$pushd` | `string directory` | Same as `$cd` but pushes the current directory to a stack before doing the cd |
+| `$popd` | none | Return to the directory previous to the last `$pushd` call |
+| `$scale` | `float flScale` | Scale the model on all axes by a scalar value |
+| `$root` | `string boneName` | Set the name of the root bone |
+| `$controller` | | |
+| `$screenalign` | `string boneName, string type = ["sphere", "cylinder", "billboard"]` | Align bone with screen |
+| `$worldalign` | `string boneName` | Align bone with world |
+| `$keepupright` | `string boneName` | Keeps a bone upright |
+| `$model` | | |
+| `$collisionmodel` | `string modelName, [optional block]` | Set the collision model for the mesh |
+| `$collisionjoints` | `string modelName, [optional block]` | Set the collision model for the mesh, with separate joints |
+| `$collisiontext` | | |
+| `$appendsource` | | |
+| `$body` | | |
+| `$prefer_fbx` | | |
+| `$bodygroup` | | |
+| `$appendblankbodygroup` | | |
+| `$bodygrouppreset` | | |
+| `$animation` | | |
+| `$autocenter` | | |
+| `$sequence` | | |
+| `$append` | | |
+| `$prepend` | | |
+| `$continue` | | |
+| `$declaresequence` | | |
+| `$declareanimation` | | |
+| `$cmdlist` | | |
+| `$animblocksize` | | |
+| `$weightlist` | | |
+| `$defaultweightlist` | | |
+| `$ikchain` | | |
+| `$ikautoplaylock` | | |
+| `$eyeposition` | | |
+| `$illumposition` | | |
+| `$origin` | | |
+| `$originbones` | | |
+| `$upaxis` | | |
+| `$bbox` | | |
+| `$bboxonlyverts` | | |
+| `$cbox` | | |
+| `$gamma` | | |
+| `$texturegroup` | | |
+| `$hgroup` | | |
+| `$hbox` | | |
+| `$hboxset` | | |
+| `$surfaceprop` | | |
+| `$jointsurfaceprop` | | |
+| `$contents` | `string contents = ["grate", "ladder", "solid", "monster", "notsolid"]` | |
+| `$jointcontents` | `string jointName, string contents = ["grate", "ladder", "solid", "monster", "notsolid"]` | |
+| `$attachment` | | |
+| `$redefineattachment` | | |
+| `$bonemerge` | | |
+| `$bonealwayssetup` | | |
+| `$externaltextures` | | |
+| `$cliptotextures` | | |
+| `$skinnedLODs` | | |
+| `$renamebone` | | |
+| `$stripboneprefix` | | |
+| `$renamebonesubstr` | | |
+| `$collapsebones` | | |
+| `$collapsebonesaggressive` | | |
+| `$alwayscollapse` | | |
+| `$proceduralbones` | | |
+| `$skiptransition` | | |
+| `$calctransitions` | | |
+| `$staticprop` | none | Mark this model as a static prop |
+| `$zbrush` | none | Enable some special processing for zbrush authored models. Models marked with this have their texcoords smoothed. This is very expensive! |
+| `$realignbones` | | |
+| `$forcerealign` | | |
+| `$lod` | | |
+| `$shadowlod` | | |
+| `$poseparameter` | | |
+| `$heirarchy` | | Lol, lmao|
+| `$hierarchy` | | |
+| `$insertbone` | | |
+| `$limitrotation` | | |
+| `$definebone` | | |
+| `$jigglebone` | | |
+| `$includemodel` | | |
+| `$opaque` | none | Force this model to be opaque. Removes any transparency flags |
+| `$mostlyopaque` | | |
+| `$keyvalues` | `block` | Defines a block of key-value pairs. These will be embedded into the model |
+| `$obsolete` | none | Marks this model as obsolete. It will show the obsolete material in-game |
+| `$renamematerial` | | |
+| `$renamematerialsubstr` | | |
+| `$overridematerial` | | |
+| `$stripmaterialpaths` | | |
+| `$fakevta` | | |
+| `$noforcedfade` | | |
+| `$skipboneinbbox` | | |
+| `$forcephonemecrossfade` | | |
+| `$lockbonelengths` | | |
+| `$unlockdefinebones` | | |
+| `$constantdirectionallight` | `float flDirLightDot` | Set the constant directional light dot product. Must be between 0 and 1, floating point number |
+| `$minlod` | `int minLod` | Set the min lod |
+| `$allowrootlods` | | |
+| `$bonesaveframe` | | |
+| `$ambientboost` | none | Indicate that the model should be rendered with an ambient boost |
+| `$centerbonesonverts` | | |
+| `$donotcastshadows` | none | Indicate that the model should not cast any shadows |
+| `$casttextureshadows` | none | Indicate that this model should cast texture-based shadows in vrad, only applies to prop_static |
+| `$motionrollback` | | |
+| `$sectionframes` | | |
+| `$clampworldspace` | | |
+| `$maxeyedeflection` | | |
+| `$addsearchdir` | | |
+| `$phyname` | | |
+| `$subd` | none | Indicate that we have a quad-only catmull-clark subd mesh in the model |
+| `$boneflexdriver` | | |
+| `$maxverts` | `int maxVerts` | Set the max verts on the model. Must be in range [1024, 65536] |
+| `$preservetriangleorder` | | |
+| `$qcassert` | | |
+| `$lcaseallsequences` | | |
+| `$defaultfadein` | | |
+| `$defaultfadeout` | | |
+| `$cloth` | | |
+| `$clothplanecollision` | | |
+| `$allowactivityname` | | |
+| `$collisionprecision` | | |
+| `$erroronsequenceremappingfailure` | | |
+| `$erroronsequenceremappingfailure_disable` | | |
+| `$modelhasnosequences` | | |
+| `$contentrootrelative` | | |
+| `$adduvmapchannelto` | | |
+| `$section` | | |
+| `$sectionenable` | | |
+| `$sectiondisable` | | |
+
+

--- a/pages/shared/reference/util/vfont.md
+++ b/pages/shared/reference/util/vfont.md
@@ -1,0 +1,28 @@
+---
+title: vfont
+---
+
+# vfont
+
+vfont is a compiler/decompiler for Valve's encrypted font files. Unlike previous branches, `vfont` is combined into a single executable that does both compilation and decompilation. This tool is available for Windows and Linux.
+
+## Help Text
+
+```
+----------------------------------------------------------------------------------
+vfont - Copyright Valve Software (Aug 28 2022)
+Usage: vfont inputFontFilename [outputFontFilename]
+
+Example Usage:
+Convert from a TTF to a vfont: vfont font.ttf
+Convert from a vfont to a TTF: vfont font.vfont
+Custom output name:            vfont filename.ttf otherfilename.vfont
+----------------------------------------------------------------------------------
+```
+
+## Examples
+
+Example 1: Decompiling a vfont file. Output will be `myfont.ttf`
+```
+vfont myfont.vfont
+```

--- a/pages/shared/reference/util/vrad.md
+++ b/pages/shared/reference/util/vrad.md
@@ -1,0 +1,115 @@
+---
+title: vrad
+---
+
+# vrad
+
+VRad or Valve Radiosity Simulator is the BSP compile tool responsible for generating lighting for your map. It is available for Windows and Linux.
+
+## Strata Source Features
+
+Changes over CSGO/Portal2 VRad:
+* Lighting that passes through world portals (See `-PortalTraversalLighting`)
+* `_removeaftercompile` flag for lights so they only contribute to lighting the world. They will not be emitted into the world lighting lump.
+* Improved texture shadows
+* Huge performance improvements
+* Expanded/removed limits
+* Much more!
+
+The following options have been added:
+* `-PortalTraversalLighting`
+* `-PortalTraversalAO`
+* `-aoscale`
+* `-aoradius`
+* `-aosamples`
+* `-noao`
+* `-StaticPropLightingFast`
+
+## Help Text
+
+```
+Valve Software - vrad.exe AVX2 (Mar  9 2024)
+
+      Valve Radiosity Simulator
+Command line: "vrad.exe" "-game" "p2ce"
+
+usage  : vrad [options...] bspfile
+example: vrad c:\hl2\hl2\maps\test
+
+Common options:
+
+  -v (or -verbose): Turn on verbose output (also shows more command
+  -bounce #       : Set max number of bounces (default: 100).
+  -fast           : Quick and dirty lighting.
+  -fastambient    : Per-leaf ambient sampling is lower quality to save compute time.
+  -final          : High quality processing. equivalent to -extrasky 16.
+  -finitefalloff  : use an alternative falloff model that falls off to exactly zero at the zero_percent_distance.
+  -extrasky n     : trace N times as many rays for indirect light and sky ambient.
+  -low            : Run as an idle-priority process.
+  -mpi            : Use VMPI to distribute computations.
+  -rederror       : Show errors in red.
+
+  -vproject <directory> : Override the VPROJECT environment variable.
+  -game <directory>     : Same as -vproject.
+
+Other options:
+  -dump           : Write debugging .txt files.
+  -dumpnormals    : Write normals to debug files.
+  -dumptrace      : Write ray-tracing environment to debug files.
+  -threads        : Control the number of threads vbsp uses (defaults to the #
+                    or processors on your machine).
+  -lights <file>  : Load a lights file in addition to lights.rad and the
+                    level lights file.
+  -noextra        : Disable supersampling.
+  -debugextra     : Places debugging data in lightmaps to visualize
+                    supersampling.
+  -smooth #       : Set the threshold for smoothing groups, in degrees
+                    (default 45).
+  -dlightmap      : Force direct lighting into different lightmap than
+                    radiosity.
+  -stoponexit      : Wait for a keypress on exit.
+  -mpi_pw <pw>    : Use a password to choose a specific set of VMPI workers.
+  -nodetaillight  : Don't light detail props.
+  -centersamples  : Move sample centers.
+  -luxeldensity # : Rescale all luxels by the specified amount (default: 1.0).
+                    The number specified must be less than 1.0 or it will be
+                    ignored.
+  -loghash        : Log the sample hash table to samplehash.txt.
+  -onlydetail     : Only light detail props and per-leaf lighting.
+  -maxdispsamplesize #: Set max displacement sample size (default: 512).
+  -softsun <n>    : Treat the sun as an area light source of size <n> degrees.                    Produces soft shadows.
+                    Recommended values are between 0 and 5. Default is 0.
+  -FullMinidumps  : Write large minidumps on crash.
+  -chop           : Smallest number of luxel widths for a bounce patch, used on edges
+  -maxchop      : Coarsest allowed number of luxel widths for a patch, used in face interiors
+  -LargeDispSampleRadius: This can be used if there are splotches of bounced
+                          light on terrain. The compile will take longer, but
+                          it will gather light across a wider area.
+  -StaticPropLighting   : generate baked static prop vertex lighting
+  -StaticPropLightingFinal   : generate baked static prop vertex lighting (uses higher/final quality processing)
+  -StaticPropPolys   : Perform shadow tests of static props at polygon precision
+  -OnlyStaticProps   : Only perform direct static prop lighting (vrad debug option)
+  -StaticPropNormals : when lighting static props, just show their normal vector
+  -StaticPropBounce  : Enable static props to bounce light. Experimental option, doesn't work with VMPI right now.
+  -textureshadows : Allows texture alpha channels to block light - rays intersecting alpha surfaces will sample the texture
+  -noskyboxrecurse : Turn off recursion into 3d skybox (skybox shadows on world)
+  -nossprops      : Globally disable self-shadowing on static props
+
+  -PortalTraversalLighting : Allow light to teleport through (static) portals.
+  -PortalTraversalAO       : Allow AO calculations to teleport through (static) portals. SLOW!
+
+  -aoscale <float>  : Sets the ambient occlusion scale. Can't be used with -aoradius
+  -aoradius <float> : Sets the ambient occlusion radius
+  -aosamples <int>  : Sets the number ambient occlusion samples. Default is 32
+  -ambient <vector> : Sets the ambient term. Can be used to tweak lightmap color
+  -reflectivityscale <float> : Sets the reflectivity scale for all surfaces. Defaults to 1.0
+  -disppatchradius <float> : Sets the maximum radius allowed for displacement patches
+  -dispchop <float> : Number of luxel widths for a patch. Default is 8
+  -ldr              : Enables generation of LDR lightmaps
+  -hdr              : Enables generation of HDR lightmaps
+  -both             : Enables generation of both LDR and HDR lightmaps
+  -staticpropsamplescale <float> : Extra sampling factor for indirect light for static props
+  -ambientfromleafcenters : Samples ambient lighting from the center of the leaf
+  -LeafAmbientSampleReduction <float> : Reduction factor for ambient samples. Defaults to 1.0
+  -unlitdetail      : Disables lighting for detail props 
+```

--- a/pages/shared/reference/util/vtex.md
+++ b/pages/shared/reference/util/vtex.md
@@ -1,0 +1,43 @@
+---
+title: vtex
+---
+
+# vtex
+
+NOTE: This tool was replaced with [vtex2](/shared/reference/util/vtex2)!
+
+vtex is a command line utility that builds VTF files. It is available for Windows and Linux.
+
+## Help Text
+
+```
+  Usage: vtex [-outdir dir] [-nopause] [-mkdir] [-compress level] [-shader ShaderName] [-vmtparam Param Value] tex1.txt tex2.txt ...
+
+  -quiet            : don't print anything out, don't pause for input
+  -warningsaserrors : treat warnings as errors
+  -nopause          : don't pause for input
+  -nomkdir          : don't create destination folder if it doesn't exist
+  -shader           : make a .vmt for this texture, using this shader (e.g. "vtex -shader UnlitGeneric blah.tga")
+  -vmtparam         : adds parameter and value to the .vmt file
+  -outdir <dir>     : write output to the specified dir regardless of source filename and vproject
+  -deducepath       : deduce path of sources by target file names
+  -extractsrc       : extract approximate src art out of a vtf
+  -dontbuild        : don't build the input files into VTFs (usually used with extractsrc)
+  -quickconvert     : use with "-dontusegamedir -quickconvert" to upgrade old .vmt files
+  -dontusegamedir   : output files in same folder as inputs (for use with -extractsrc and -quickconvert)
+  -crcvalidate      : validate .vmt against the sources
+  -crcforce         : generate a new .vmt even if sources crc matches
+  -nopsd            : skip .psd files (e.g. use this with "vtex *.*")
+  -notga            : skip .tga files (e.g. use this with "vtex *.*")
+  -oldcubepath      : old cubemap method, expects 6 input files, suffixed: 'up', 'dn', 'lf', 'rt', 'ft', 'bk'
+  -panorama         : performs the following: 1. generate _medium.vtf (half res) and _small.vtf (quarter res) unless -nomultires is specified.
+                                              2. compress to YCoCg if possible, can 'upgrade' a source .vtf to YCoCg
+                                              3. does not generate mip-maps (override this by specifying TEXTUREFLAGS_ALLMIPS in a config file)
+  -nomultires       : only applicable if -panorama used, will avoid generating multi-res vtf files
+  -compress <level> : compress the input using DEFLATE (level 0 = no compression, level -1 = default)
+
+        eg: -vmtparam $ignorez 1 -vmtparam $translucent 1
+
+  Note that you can use wildcards and that you can also chain them
+  e.g. materialsrc/monster1/*.tga materialsrc/monster2/*.tga
+```

--- a/pages/shared/reference/util/vtex2.md
+++ b/pages/shared/reference/util/vtex2.md
@@ -1,0 +1,135 @@
+---
+title: vtex2
+---
+
+# vtex2
+
+vtex2 is a Valve Texture Format conversion and creation tool. It has a CLI and a GUI component for viewing, packing and otherwise converting the files.
+
+The source code is availible [here on GitHub](https://github.com/StrataSource/vtex2).
+
+## Usage
+
+Command help documentation and usage examples can be shown on the command line using `vtex2 --help`.
+
+For action-specific help, use `vtex2 <action> --help`.
+
+### Creating VTFs
+
+Creating a VTF can be done with the `vtex2 convert` action.
+
+For example, the following command will create a VTF called `some-file.vtf` with the format `BGRA8888`:
+```
+vtex2 convert -f bgra8888 some-file.jpg
+```
+
+If you pass a directory to `vtex2 convert`, it will convert all files in that directory. The `-r` or `--recursive` parameter
+will cause the program to descend and process subdirectories too.
+
+Full list of options:
+```
+USAGE: vtex2 convert [OPTIONS] file...
+
+  Convert a generic image file to VTF
+
+Options:
+  --bumpscale                      Bumpscale
+  --clamps                         Clamp on S axis
+  --clampt                         Clamp on T axis
+  --clampu                         Clamp on U axis
+  --no-mips                        Disable mipmaps for this texture
+  --pointsample                    Set point sampling method
+  --srgb                           Process this image in sRGB color space
+  --start-frame                    Animation frame to start on
+  --thumbnail                      Generate thumbnail for the image
+  --trilinear                      Set trilinear sampling method
+  --version                        Set the VTF version to use
+  -c,--compress [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
+                                   DEFLATE compression level to use. 0=none, 9=max. This will force VTF version to 7.6
+  -f,--format [rgba8888, abgr8888, rgb888, bgr888, rgb565, i8, ia88, p8, a8, rgb888_bluescreen, bgr888_bluescreen, argb8888, bgra8888, dxt1, dxt3, dxt5, bgrx8888, bgr565, bgrx5551, bgra4444, dxt1_onebitalpha, bgra5551, uv88, uvwq8888, rgba16161616f, rgba16161616, uvlx8888, r32f, rgb323232f, rgba32323232f, ati2n, ati1n, bc7]
+                                   Image format of the VTF
+  -gl,--opengl                     Treat the incoming normal map as a OpenGL normal map
+  -h,--height                      Height of the output VTF
+  -m,--mips                        Number of mips to generate
+  -n,--normal                      Create a normal map
+  -o,--output                      Name of the output VTF
+  -r,--recursive                   Recursively process directories
+  -w,--width                       Width of the output VTF
+  file                             Image file to convert or directory to process
+```
+
+### Extracting image data from VTF
+
+Extracting image data from a VTF can be done using `vtex2 extract`.
+
+For example, the following command will extract the VTF to `some-file.jpg`:
+```
+vtex2 extract -f jpg some-file.vtf
+```
+
+If you pass a directory to `vtex2 extract`, it will convert all files in that directory. The `-r` or `--recursive` parameter
+will cause the program to descend and process subdirectories too.
+
+Full list of options:
+```
+USAGE: vtex2 extract [OPTIONS] file...
+
+  Converts a VTF into png, tga, jpeg, bmp or hdr image file
+
+Options:
+  -f,--format [png, jpeg, jpg, tga, bmp, hdr]
+                                   Output format to use
+  -m,--mip                         Mipmap to extract from image
+  -na,--no-alpha                   Exclude alpha channel from converted image
+  -o,--output                      File to place the output in
+  -r,--recursive                   Recursively process directories
+  file                             VTF file to convert or directory to process
+```
+
+### Displaying VTF Info
+
+The `vtex2 info` command can be used to display some info about VTF files.
+
+Full list of options:
+```
+USAGE: vtex2 info [OPTIONS] file...
+
+  Displays info about a VTF file
+
+Options:
+  -a,--all                         Display all detailed info about a VTF
+  -r,--resources                   List all resource entries in the VTF
+  file                             VTF file to process
+```
+
+### Channel pack a VTF
+
+The `vtex2 pack` command can be used pack images into channels of a VTF.
+
+Full list of options:
+```
+USAGE: vtex2 pack [OPTIONS] -o...
+
+  Packs images into a MRAO or normal+height map
+
+Options:
+  -aoc,--ao-const                  If no AO map is specified, fill AO value with this constant value
+  -aomap,--ao-map                  AO map to pack [MRAO only]
+  -gl,--opengl                     Treat the incoming normal map as a OpenGL normal map
+  -h,--height                      Height (dimension) of output image. If set to -1, autodetect from input maps
+  -hc,--height-const               If no height map is specified, fill height value with this constant value
+  -hmap,--height-map               Height map to pack
+  -m,--mips                        Number of mipmaps for output image
+  -mc,--metalness-const            If no metalness map is specified, fill metalness value with this constant value
+  -mmap,--metalness-map            Metalness map to pack [MRAO only]
+  -mrao,--mrao                     Create MRAO map
+  -n,--normal                      Create packed normal+height map
+  -nmap,--normal-map               Normal map to pack
+  -o,--outfile                     Output file name
+  -rc,--roughness-const            If no roughness map is specified, fill roughness value with this constant value
+  -rmap,--roughness-map            Roughness map to pack [MRAO only]
+  -tmask,--tint-mask               Tint mask texture to use [MRAO only]
+  -w,--width                       Width of output image. If set to -1, autodetect from input maps
+```
+
+


### PR DESCRIPTION
This MR merges in the new pages from the old GitHub wiki, closing issue #53 

This also adds very basic documentation for vtex and vtex2 and remaps the urls under `reference/reference` to `reference/general`