### PR TITLE
Proposal: Hotspot alt_group flag

### DIFF
--- a/docs/modding/overview/vtf-hotspot-resource.md
+++ b/docs/modding/overview/vtf-hotspot-resource.md
@@ -48,7 +48,7 @@ struct HotspotRect_t {
 
 Orientation randomization is defined within the flags of each rect. Although these are defined per-rect, it is recommended that editors implement batch editing for ease of use.
 
-Regions can also be defined as belonging to the alternate group via the `alt_group` flag. Regions with this flag will not be selected unless an implementation-defined keyboard modifier key is pressed, and vice-versa.
+Regions with the `alt_group` flag should be excluded from random selection by default, and be exclusively randomly selected when an implementation-specific modifier key is active. For consistency, the left-hand Alt key is recommended for this purpose.
 
 ```cpp
 enum class HotspotRectFlags_t : unsigned char {

--- a/docs/modding/overview/vtf-hotspot-resource.md
+++ b/docs/modding/overview/vtf-hotspot-resource.md
@@ -46,11 +46,14 @@ struct HotspotRect_t {
 };
 ```
 
-Orientation is defined within the flags of each rect. Although these are defined per-rect, it is recommended that editors implement batch editing for ease of use.
+Orientation randomization is defined within the flags of each rect. Although these are defined per-rect, it is recommended that editors implement batch editing for ease of use.
+
+Regions can also be defined as belonging to the alternate group via the `alt_group` flag. Regions with this flag will not be selected unless an implementation-defined keyboard modifier key is pressed, and vice-versa.
 
 ```cpp
 enum class HotspotRectFlags_t : unsigned char {
 	enable_rotation   = 0x1, // Can this region be randomly rotated?
 	enable_reflection = 0x2, // Can this region be randomly horizontally flipped?
+	alt_group         = 0x4, // If true, this region belongs to the alternate group.
 };
 ```


### PR DESCRIPTION
This proposal adds a flag to regions that allows them to be excluded from random selection by default, and be exclusively randomly selected when a modifier key is pressed. This would allow for users to quickly apply a specific set of regions without swapping materials or relying on random chance to get the specific subset regions they are looking for.

See the [Hammer-Hotspots `feat/alt-group` branch](https://github.com/koerismo/Hammer-Hotspots/compare/main...feat/alt-group) for an implementation of this feature.
