### PR TITLE
Update ParallaxCorrectedCubemaps.md

### DIFF
--- a/docs/material/Parallax-Corrected-Cubemaps/ParallaxCorrectedCubemaps.md
+++ b/docs/material/Parallax-Corrected-Cubemaps/ParallaxCorrectedCubemaps.md
@@ -5,10 +5,10 @@ title: Parallax Corrected Cubemaps
 
 ![Click on the hand holding a mask](images/guide_parallax_cubemaps.jpg)
 
-This page covers Strata implementation of Parallax-Corrected Cubemaps, created with a combination of custom entities and materials.
+This page covers Strata's implementation of Parallax-Corrected Cubemaps. These cubemaps are created with a combination of the `env_cubemap` point entity and the `parallax_obb` brush entity.
 
 ## Overview
-https://docs.momentum-mod.org/shaders/parallax_corrected_cubemaps/ it's came from momentum mod
+This tutorial is from the [Momentum Mod Wiki](https://docs.momentum-mod.org/shaders/parallax_corrected_cubemaps/).
 
 > [!NOTE]
 > Thanks to Brian Charles for his work on this feature.
@@ -16,7 +16,7 @@ https://docs.momentum-mod.org/shaders/parallax_corrected_cubemaps/ it's came fro
 
 ## Prerequisites 
 * Be proficient in using the Hammer Editor
-* Have the momentum/p2ce/revolution.fgd in your Hammer configuration
+* Have the appropriate `.fgd` file for your game in your Hammer configuration
 * Know how to use the developer console
 ## Components of a Parallax-Corrected Cubemap
 
@@ -29,16 +29,16 @@ In Hammer, Parallax-Corrected Cubemaps need two entities to function correctly:
 ![Click on the hand holding a mask](images/cube_0.jpg)
 
 > [!NOTE]
-> You may notice a box appear in the centre of the brush when you tie it to a parallax_obb entity like shown above.
+> If you are using Momentum Mod, you may notice a box appear in the centre of the brush when you tie it to a parallax_obb entity like shown above.
 > This is normal and allows you to more easily select the brush if you have made it match the shape of the room.
 
 Any regular LightmappedGeneric materials will still be able to use the cubemap as normal, this feature simply adds functionality on top of the existing env_cubemap in conjunction with an extra entity and shader to use inside .VMT files.
 
 > [!TIP]
 > There are some important things to take note of:
-> The parallax_obb entity must be a single box brush
-> The Parallax-Corrected cubemap is still built the same way regular cubemaps are.
-> This means that you may have distortion in the reflections depending on where you place the env_cubemap and the shape of the parallax_obb brush.
+> * The parallax_obb entity must be a single box brush
+> * The Parallax-Corrected cubemap is still built the same way regular cubemaps are. This means that you may have distortion in the reflections depending on where you place the env_cubemap and the shape of the parallax_obb brush.
+>
 > This example has a wide room with a low ceiling as well as the cubemap entity not quite in the centre:
 
 ![Click on the hand holding a mask](images/cube_4.jpg)

--- a/docs/material/Parallax-Corrected-Cubemaps/ParallaxCorrectedCubemaps.md
+++ b/docs/material/Parallax-Corrected-Cubemaps/ParallaxCorrectedCubemaps.md
@@ -29,7 +29,7 @@ In Hammer, Parallax-Corrected Cubemaps need two entities to function correctly:
 ![Click on the hand holding a mask](images/cube_0.jpg)
 
 > [!NOTE]
-> If you are using Momentum Mod, you may notice a box appear in the centre of the brush when you tie it to a parallax_obb entity like shown above.
+> In older versions of Momentum Mod, you may notice a box appear in the centre of the brush when you tie it to a parallax_obb entity like shown above.
 > This is normal and allows you to more easily select the brush if you have made it match the shape of the room.
 
 Any regular LightmappedGeneric materials will still be able to use the cubemap as normal, this feature simply adds functionality on top of the existing env_cubemap in conjunction with an extra entity and shader to use inside .VMT files.


### PR DESCRIPTION
* Edited the grammar of the intro text and credit to the momentum wiki.
* Edited 2nd bullet point of prerecs. The slashes made it look like a file system path, at least at first glance. Also, the hammer included with each game should already have the FGD in the default config
* Fixed the text in the tip being on the same line.