### PR TITLE
docs: change title of a clustered lighting page

### DIFF
--- a/docs/lighting/clustered/differences.md
+++ b/docs/lighting/clustered/differences.md
@@ -1,5 +1,5 @@
 ---
-title: _rt light entities
+title: Real-time Light Entities
 features:
     - USE_CLUSTERED
 ---


### PR DESCRIPTION
`_rt` seemed bad to have in the title, that's all.