### PR TITLE
modify the link to adjust the correct "CSGO Panorama Events" link

### DIFF
--- a/docs/panorama/overview/getting-started.md
+++ b/docs/panorama/overview/getting-started.md
@@ -52,9 +52,6 @@ articles target CSGO and do not cover any new Strata Source features.
 
 -   [CSGO CSS Properties](https://developer.valvesoftware.com/wiki/CSGO_Panorama_CSS_Properties) - Strata Source currently uses
     all the CSS properties of CS:GO.
--   [CSGO Panorama Events](https://developer.valvesoftware.com/wiki/CSGO_Panorama_Events) - A majority of these events are either
-    nonfunctional or not present in the Strata Source, however general events that do not pertain to CSGO should be present and
-    functional.
 -   [CSGO Panorama API](https://developer.valvesoftware.com/wiki/CSGO_Panorama_API) - Contains many API functions that can be ran
     in Panorama JavaScript files. Some are specific to CSGO, and either not present or not functional in the Strata Source.
 

--- a/docs/panorama/overview/getting-started.md
+++ b/docs/panorama/overview/getting-started.md
@@ -52,6 +52,9 @@ articles target CSGO and do not cover any new Strata Source features.
 
 -   [CSGO CSS Properties](https://developer.valvesoftware.com/wiki/CSGO_Panorama_CSS_Properties) - Strata Source currently uses
     all the CSS properties of CS:GO.
+-   [CSGO Panorama Events](https://developer.valvesoftware.com/wiki/CS:GO_Panorama_Events)- A majority of these events are either
+    nonfunctional or not present in the Strata Source, however general events that do not pertain to CSGO should be present and
+    functional.
 -   [CSGO Panorama API](https://developer.valvesoftware.com/wiki/CSGO_Panorama_API) - Contains many API functions that can be ran
     in Panorama JavaScript files. Some are specific to CSGO, and either not present or not functional in the Strata Source.
 


### PR DESCRIPTION
the I surrounded is useless, because it's has been have been because in the link it's was "csgo" but for some reason, someone think it's was a good idea to put "cs:go" which broke it, so this PR make it to modify  the line I I surrounded for that can work.
<img width="1422" height="556" alt="image" src="https://github.com/user-attachments/assets/a9c13014-fcb4-47e9-8089-b8ecf5eb7b1f" />
<img width="1594" height="481" alt="image" src="https://github.com/user-attachments/assets/e63b0cf7-094a-483c-8828-e1bdb776be0a" />
