### PR TITLE
Update initial shadow size recommendations

### DIFF
--- a/docs/lighting/clustered/quick_start.md
+++ b/docs/lighting/clustered/quick_start.md
@@ -13,7 +13,7 @@ features:
 2. Set "Specular Light Mode" to "Dynamic Only"
 3. Set "Direct Light Mode" to "Dynamic Only"
 4. Set "Indirect Light Mode" to "Static Only"
-5. Set "Initial Shadow Size" to 6 or 7
+5. Set "Initial Shadow Size" to 2 or 3
 6. Make sure the "Shadowed" flag is **checked**
 7. Set "50 percent falloff distance" and "0 percent falloff distance" KeyValues to adjust the look and feel
 8. For best results, use PBR textures with appropriate MRAOs and normal maps
@@ -26,7 +26,7 @@ features:
 2. Set "Specular Light Mode" to "Dynamic Only"
 3. Set "Direct Light Mode" to "Dynamic Only"
 4. Set "Indirect Light Mode" to "None"
-5. Set "Initial Shadow Size" to something around 5
+5. Set "Initial Shadow Size" to something around 1
 6. Make sure the "Shadowed" flag is **checked**
 7. Set "50 percent falloff distance" and "0 percent falloff distance" KeyValues to adjust the look and feel
 8. For best results, use PBR textures with appropriate MRAOs and normal maps


### PR DESCRIPTION
This page in the wiki is outdated and leads users to make overtly expensive lights.

<img width="959" height="256" alt="image" src="https://github.com/user-attachments/assets/50967673-6b33-42aa-be4a-044256d336d5" />

This leads to errors like this with just one light in the entire map:

<img width="473" height="59" alt="image" src="https://github.com/user-attachments/assets/c7fb5c9b-cd13-4162-93da-ecadfd1103a9" />

In the words of Smaed, team member on Portal 2: Community Edition:

> yeah that needs to be changed, that was written before changes were made to integrate shadow graphics options in the system that add a base 4 to exponent on highest settings
so you want 2 or 3 in reality to get what the guide is talking about
7 is trying to allocate 2048x2048 shadows per point light shadow face

My PR would reduce the amount to what is recommended to fix the misinformation.

This is my first time contributing to the Strata engine! Let me know if any issues arise.