### PR TITLE
Updated initial shadow size recommendations, again.

### DIFF
--- a/docs/lighting/clustered/quick_start.md
+++ b/docs/lighting/clustered/quick_start.md
@@ -13,7 +13,7 @@ features:
 2. Set "Specular Light Mode" to "Dynamic Only"
 3. Set "Direct Light Mode" to "Dynamic Only"
 4. Set "Indirect Light Mode" to "Static Only"
-5. Set "Initial Shadow Size" to 2 or 3
+5. Set "Initial Shadow Size" to 5 or 6
 6. Make sure the "Shadowed" flag is **checked**
 7. Set "50 percent falloff distance" and "0 percent falloff distance" KeyValues to adjust the look and feel
 8. For best results, use PBR textures with appropriate MRAOs and normal maps
@@ -26,7 +26,7 @@ features:
 2. Set "Specular Light Mode" to "Dynamic Only"
 3. Set "Direct Light Mode" to "Dynamic Only"
 4. Set "Indirect Light Mode" to "None"
-5. Set "Initial Shadow Size" to something around 1
+5. Set "Initial Shadow Size" to something around 4
 6. Make sure the "Shadowed" flag is **checked**
 7. Set "50 percent falloff distance" and "0 percent falloff distance" KeyValues to adjust the look and feel
 8. For best results, use PBR textures with appropriate MRAOs and normal maps

--- a/docs/lighting/clustered/troubleshooting.md
+++ b/docs/lighting/clustered/troubleshooting.md
@@ -14,13 +14,13 @@ This is a list of currently known issues and some troubleshooting tips for any i
 * For cheap static shadows, make sure "Direct light mode" is set to "Static Only" for your light entity. With this option, specular lighting will still travel through walls. If that's an issue for your map, you may need to use dynamic shadows or turn off specular.
 * For dynamic shadows, make sure the "Shadowed" spawn flag is enabled on the light that should be casting shadows.
 
-### "I set the Shadowed spawn flag, but there are still no shadows/light leaks through walls"
+### "I set the Shadowed spawn flag, but there are still no shadows / light leaks through walls"
 
 * You have too many dynamic shadows updating at once. Remember that **each shadow size level increases the shadow atlas size by a factor of 4**, and **the shadow atlas cannot have exceed a value of 7**, so if there are for example 2 `light_rt`s with shadow size of 6 close to each other, they will overlap and therefore will not produce any shadows. However, there is an unstable workaround, where by enabling `light_rt`s one by one they have a chance to keep their shadows.
 
 ### "My dynamic shadows are blurry"
 
-* Set the "Initial Shadow Size" keyvalue of your light to something around 6.
+* Set the "Initial Shadow Size" keyvalue of your light to something around 6. Remember that the higher the shadow size, the bigger piece of shadow atlas it will take.
 
 ### "My dynamic shadows are 'frozen' or don't update" / "Some entities like rockets don't cast shadows"
 


### PR DESCRIPTION
The previous pull request about clustered lighting suggested using shadow size of 1, which barely produces any shadows. So this update brings back the values before the update, as well as the additional note about shadow sizes in troubleshooting.