### PR TITLE
Remove duplicate -dedicated launch option in Launch Options page

### DIFF
--- a/docs/modding/overview/launchoptions.md
+++ b/docs/modding/overview/launchoptions.md
@@ -23,7 +23,6 @@ of launch options, please see
 | -debug_dynamic_mounts    | Enables verbose debug printing for debugging dynamic mounts                                                |
 | -safemode                | Runs the game in safe mode, disabling additional configured mounts                                         |
 | -jolt                    | Runs the game with vphysics_jolt (EXPERIMENTAL!)                                                           |
-| -dedicated               | Launch the dedicated server                                                                                |
 | -tools                   | Launch the game in engine tools mode                                                                       |
 
 # Linux-only options


### PR DESCRIPTION
Remove the second entry for `-dedicated` in [this](https://wiki.stratasource.org/modding/overview/launchoptions) page on the wiki.

"Launches the game as a dedicated server" seems more descriptive to me than "Launch the dedicated server", so I kept that description. I've tested the changes locally.