### PR TITLE
Added Code Blocks Article and Made Sure To Mention To Use `npm run cf-build`

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,4 +32,4 @@ On the first run, the `run` script will clone and initialize the Wiki software s
 Site build output files are placed in `site/build`, which can be served using the HTTP server of choice.
 
 > [!NOTE]
-> `npm run cf-build` can be used to verify that links, files, and other aspects of the Wiki to ensure it will run correctly. ***If you are contributing to the Wiki and make a pull request with changes, require that you use this locally to enforce working Wiki documentation.***
+> `npm run cf-build` can be used to verify that links, files, and other aspects of the Wiki to ensure it will run correctly. ***If you are contributing to the Wiki and make a pull request with changes, we require you to use this to build locally to ensure that there are no errors in production builds***

--- a/README.md
+++ b/README.md
@@ -30,3 +30,6 @@ On the first run, the `run` script will clone and initialize the Wiki software s
 > All future executions of `run` will just build and run the server. If you wish to run the Wiki instead of waiting for it to build, run `npm run dev`.
 
 Site build output files are placed in `site/build`, which can be served using the HTTP server of choice.
+
+> [!NOTE]
+> `npm run cf-build` can be used to verify that links, files, and other aspects of the Wiki to ensure it will run correctly. ***If you are contributing to the Wiki and make a pull request with changes, require that you use this locally to enforce working Wiki documentation.***

--- a/docs/contribute/basics/getting-started.md
+++ b/docs/contribute/basics/getting-started.md
@@ -51,7 +51,7 @@ The source can be cloned from [StrataSource/Wiki](https://github.com/StrataSourc
 Please follow the README instructions in the `StrataSource/Wiki` repository to finish setting up the Wiki once it has been cloned.
 
 > [!WARNING]
-> ***If you plan to contribute to the WIki and plan to make a pull request with your changes, we require that you run `npm run cf-build` before hand to confirm that links, images, and other pieces of the Wiki documentation are setup correctly. These will take around 3 minutes to complete but will report any issues with the build.***
+> ***If you plan to contribute to the Wiki and plan to make a pull request with your changes, we require that you run `npm run cf-build` beforehand to confirm that links, images, and other pieces of the Wiki documentation are setup correctly. This will take around 3 minutes to complete but will report any issues with the build.***
 
 ## What's Next
 

--- a/docs/contribute/basics/getting-started.md
+++ b/docs/contribute/basics/getting-started.md
@@ -50,6 +50,9 @@ The source can be cloned from [StrataSource/Wiki](https://github.com/StrataSourc
 
 Please follow the README instructions in the `StrataSource/Wiki` repository to finish setting up the Wiki once it has been cloned.
 
+> [!WARNING]
+> ***If you plan to contribute to the WIki and plan to make a pull request with your changes, we require that you run `npm run cf-build` before hand to confirm that links, images, and other pieces of the Wiki documentation are setup correctly. These will take around 3 minutes to complete but will report any issues with the build.***
+
 ## What's Next
 
 After reading the guidelines and setting up the local instance of the Strata Source Wiki, continue to [Creating & Editing Articles](creating-editing-articles).

--- a/docs/contribute/elements/code.md
+++ b/docs/contribute/elements/code.md
@@ -1,0 +1,76 @@
+---
+title: Code Blocks
+weight: 10
+---
+
+# Code Blocks
+
+The Wiki supports using backticks ( \` ) and triple backticks ( \``` ) to make code blocks for file content. Tildes ( ~ ) can also be used but most often backticks are used. Tildes are useful if triple backticks need to be escaped. (`~~~ ``` content ``` ~~~`) Single backticks are used for small singular lines or phrases while triple backticks are used for larger multiline code blocks. Double backticks can be used to to escape backticks if a literal backtick is needed.
+
+Code blocks allows for nice highlighting for various programming languages and making it easy to read files and code. Code blocks support highlighting for specific languages. Highlighting support has been added for VDF and KV files for the Source Engine. A full list of available languages that can be highlighted can be found here: <https://highlightjs.readthedocs.io/en/latest/supported-languages.html>
+
+Using triple backticks followed by the language of choice, the code block will highlight various syntax, types, and keywords with various coloring.
+
+Examples:
+
+Markdown: `` `Single Backticks` `` Preview: `Single Backticks`
+
+Markdown:
+
+~~~markdown
+```cpp
+[ClientCommand("HelloWorld", "")]
+void MyCommand(const CommandArgs@ args) {
+    Msgl("Hello world from AngelScript!");
+}
+```
+~~~
+
+Preview:
+
+```cpp
+[ClientCommand("HelloWorld", "")]
+void MyCommand(const CommandArgs@ args) {
+    Msgl("Hello world from AngelScript!");
+}
+```
+
+The Wiki adds a special feature with code blocks where a file can also be specified with the highlighting type.
+
+Example:
+
+~~~markdown
+```kv :: example_rectmap.rect
+Rectangles
+{
+    rectangle
+    {
+        min "0 0"
+        max "512 32"
+    }
+    rectangle
+    {
+        min "512 0"
+        max "768 32"
+    }
+}
+```
+~~~
+
+Preview:
+
+```kv :: example_rectmap.rect
+Rectangles
+{
+    rectangle
+    {
+        min "0 0"
+        max "512 32"
+    }
+    rectangle
+    {
+        min "512 0"
+        max "768 32"
+    }
+}
+```

--- a/docs/contribute/elements/notices.md
+++ b/docs/contribute/elements/notices.md
@@ -1,10 +1,11 @@
 ---
 title: Notices
+weight: 0
 ---
 
 # Notices
 
-Notices can be used to call out important or useful info.
+Notices can be used to call out important or useful info. Notices use blockquotes which get turned into notices by the Wiki software.
 
 ## Default Notice
 

--- a/docs/modding/formats/vtf-hotspot-text-format.md
+++ b/docs/modding/formats/vtf-hotspot-text-format.md
@@ -9,24 +9,24 @@ Alongside the embedded format, Strata Source supports the Hammer++ rect format, 
 ```kv :: example_rectmap.rect
 Rectangles
 {
-	rectangle
-	{
-		min		"0 0"
-		max		"512 32"
-	}
-	rectangle
-	{
-		min		"512 0"
-		max		"768 32"
-	}
+    rectangle
+    {
+        min "0 0"
+        max "512 32"
+    }
+    rectangle
+    {
+        min "512 0"
+        max "768 32"
+    }
 }
 ```
 
 ```kv :: example_material.vmt
 LightmappedGeneric
 {
-	$basetexture "example_material"
-	%rectanglemap "example_rectmap"
+    $basetexture "example_material"
+    %rectanglemap "example_rectmap"
 }
 ```
 
@@ -37,10 +37,10 @@ Regions with the `alt` flag are excluded from the selection set by default, unle
 ```kv
 rectangle
 {
-	min		"0 0"
-	max		"256 256"
-	rotate	1			// Should this region be randomly rotated?
-	reflect	1			// Should this region be randomly horizontally flipped?
-	alt		1			// If true, this region belongs to the alternate group.
+    min "0 0"
+    max "256 256"
+    rotate  1   // Should this region be randomly rotated?
+    reflect 1   // Should this region be randomly horizontally flipped?
+    alt 1       // If true, this region belongs to the alternate group.
 }
 ```

--- a/docs/test/special/code.md
+++ b/docs/test/special/code.md
@@ -24,34 +24,50 @@ hello: worlddddddddddddddddddddddddddddddddddddddddddddd aaaaaaaaaaaaaaaaaaaaaaa
 ```kv
 mount
 {
-	// The AppID of your mod
-	620
-	{
-		"required" "1" // If 1, the game will not launch if this couldn't be mounted.
-		"head" "0" // If 1, this will add the search path to the head of the list
+    // The AppID of your mod
+    620
+    {
+        "required" "1" // If 1, the game will not launch if this couldn't be mounted.
+        "head" "0" // If 1, this will add the search path to the head of the list
 
-		// 'update' is the name of the folder to look in
-		"update"
-		{
-			"vpk" "pak01" // The vpk directive tells the engine to look for update/pak01_XXX.vpk
-		}
+        // 'update' is the name of the folder to look in
+        "update"
+        {
+            "vpk" "pak01" // The vpk directive tells the engine to look for update/pak01_XXX.vpk
+        }
 
-		"portal2_dlc2"
-		{
-			"vpk" "pak01" // Add portal2_dlc2/pak01_XXX.vpk
-			"dir" "maps" // Add the portal2_dlc2/maps directory to the search path
-			"dir" "models" // Add the portal2_dlc2/models directory to the search path
-		}
+        "portal2_dlc2"
+        {
+            "vpk" "pak01" // Add portal2_dlc2/pak01_XXX.vpk
+            "dir" "maps" // Add the portal2_dlc2/maps directory to the search path
+            "dir" "models" // Add the portal2_dlc2/models directory to the search path
+        }
 
-		"portal2_dlc1"
-		{
-			"vpk" "pak01"
-		}
+        "portal2_dlc1"
+        {
+            "vpk" "pak01"
+        }
 
-		"portal2"
-		{
-			"vpk" "pak01"
-		}
-	}
+        "portal2"
+        {
+            "vpk" "pak01"
+        }
+    }
+}
+```
+
+```kv :: example_rectmap.rect
+Rectangles
+{
+    rectangle
+    {
+        min "0 0"
+        max "512 32"
+    }
+    rectangle
+    {
+        min "512 0"
+        max "768 32"
+    }
 }
 ```


### PR DESCRIPTION
Adds an article on code blocks, since there are some helpful things we do with them on the software side that should be mentioned. Also made sure to mention using `npm run cf-build` in both the Wiki and on the README.